### PR TITLE
Hotfix/session request

### DIFF
--- a/src/entities/Lesta/model/selectors/lestaUserDataSelectors/index.ts
+++ b/src/entities/Lesta/model/selectors/lestaUserDataSelectors/index.ts
@@ -38,7 +38,7 @@ export const getUserRatingValues = (state: StateSchema) => state?.lestaUserData?
 // сессии
 export const getUserLastSessionId = (state: StateSchema) => {
   if (state?.lestaUserData?.personal?.sessions?.length > 0) {
-    return [...state.lestaUserData.personal.sessions].pop();
+    return [...state.lestaUserData.personal.sessions].pop().id;
   }
   return null;
 };

--- a/src/entities/Lesta/model/services/fetchLestaUserSession/fetchLestaUserSession.ts
+++ b/src/entities/Lesta/model/services/fetchLestaUserSession/fetchLestaUserSession.ts
@@ -1,6 +1,5 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { ThunkConfig } from 'app/providers/StoreProvider';
-import { userSessionActions } from '../../slice/userSessionSlice';
 import { TUserSession } from '../../types/users';
 
 interface ThunkProps {
@@ -14,7 +13,7 @@ export const fetchLestaUserSessionById = createAsyncThunk<
   ThunkConfig<string>
   >('LESTA_USER_SESSION', async (ThunkProps, thunkAPI) => {
   // деструктурируем нужные данные из thunkAPI
-    const { rejectWithValue, dispatch, extra } = thunkAPI;
+    const { rejectWithValue, extra } = thunkAPI;
     const {
       sessionId,
       shouldRefreshSession = false,
@@ -32,10 +31,6 @@ export const fetchLestaUserSessionById = createAsyncThunk<
 
       // прокидываем ошибку, если данных нет
       if (!response.data) return rejectWithValue(serverError);
-
-      dispatch(userSessionActions.setSessionDelta({ ...response.data.delta }));
-      dispatch(userSessionActions.setSessionStatistics({ ...response.data.statistics }));
-      dispatch(userSessionActions.setSessionTanks(response.data.tanks));
 
       // возвращаем полученные данные
       return response.data;

--- a/src/entities/Lesta/model/services/fetchUserDataByLestaId/fetchUserDataByLestaId.ts
+++ b/src/entities/Lesta/model/services/fetchUserDataByLestaId/fetchUserDataByLestaId.ts
@@ -5,12 +5,12 @@ import { TUserTanks } from '../../types/tanks';
 import { TUserData } from '../../types/users';
 import { userTanksActions } from '../../slice/lestaTanksSlice';
 
-interface ThunkProps {
+export interface ThunkProps {
   id: number | number[],
   lestaAccessToken?: string,
 }
 
-interface ReturnData {
+export interface ReturnData {
   userData: TUserData;
   userTanks: TUserTanks[];
 }
@@ -35,35 +35,12 @@ export const fetchUserDataByLestaId = createAsyncThunk<ReturnData, ThunkProps, T
       // прокидываем ошибку, если данных нет
       if (!response.data) return rejectWithValue(serverError);
 
-      // записываем в стейт персональные данные
-      dispatch(userDataActions.setPersonalUserData({
-        ...response?.data?.userData?.personal,
-      }));
-
-      // записываем рейтинговые данные
-      dispatch(userDataActions.setRatingData({ ...response?.data?.userData?.rating }));
-      dispatch(userDataActions.setRatingValues({ ...response?.data?.userData?.ratingValues }));
-
-      // записываем статистику игрока
-      dispatch(userDataActions.setUserStats({ ...response?.data?.userData?.statistics }));
-
-      // записываем данные о клане игрока
-      if (response?.data?.userData?.clan) {
-        dispatch(userDataActions.setUserClan({ ...response?.data?.userData?.clan }));
-      }
-
       // записываем данные о танках игрока
       if (response?.data?.userTanks) {
         dispatch(userTanksActions.setUserTanks([...response.data.userTanks]));
         // dispatch(filterActions.setFilterData([...response.data.userTanks]));
       }
 
-      // если был передан, записываем приватные данные аккаунта
-      if (lestaAccessToken) {
-        dispatch(userDataActions.setPrivateUserData({
-          ...response?.data?.userData?.private,
-        }));
-      }
       // возвращаем полученные данные
       return response.data;
     } catch (e) {

--- a/src/entities/Lesta/model/slice/userDataSlice.ts
+++ b/src/entities/Lesta/model/slice/userDataSlice.ts
@@ -65,6 +65,14 @@ export const userDataSlice = createSlice({
       .addCase(fetchUserDataByLestaId.fulfilled, (state, { payload }) => {
         state.isLoading = false;
 
+        state.personal = payload.userData?.personal;
+        state.rating = payload.userData?.rating;
+        state.ratingValues = payload.userData?.ratingValues;
+        state.statistics = payload.userData?.statistics;
+
+        if (payload.userData?.clan) state.clan = payload.userData.clan;
+        if (payload.userData.private) state.private = payload.userData.private;
+
         if (!payload?.userData?.personal?.lestaData?.account_id) state.isNotFound = true;
       });
   },

--- a/src/entities/Lesta/model/slice/userSessionSlice.ts
+++ b/src/entities/Lesta/model/slice/userSessionSlice.ts
@@ -48,8 +48,11 @@ export const userSessionSlice = createSlice({
         state.isLoading = false;
         state.error = payload;
       })
-      .addCase(fetchLestaUserSessionById.fulfilled, (state) => {
+      .addCase(fetchLestaUserSessionById.fulfilled, (state, { payload }) => {
         state.isLoading = false;
+        state.data.delta = { ...payload.delta };
+        state.data.statistics = { ...payload.statistics };
+        state.data.tanks = payload.tanks;
       })
       .addCase(createLestaUserSession.pending, (state) => {
         state.error = '';

--- a/src/entities/User/model/slice/userSlice.ts
+++ b/src/entities/User/model/slice/userSlice.ts
@@ -1,13 +1,11 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { authByLestaOpenID } from 'features/AuthUser/index';
 import { patchCurrentUser } from 'features/editCurrentUserPorfile/index';
-import { LOCAL_STORAGE_USER_KEY } from 'shared/consts/localstorage';
 import { logoutUser } from '../services/logoutUser/logoutUser';
 import { checkUserAuth } from '../services/checkUserAuth/checkUserAuth';
 import { User, UserSchema } from '../types/user';
 
 const initialState: UserSchema = {
-  // isLoggedIn: !!localStorage.getItem(LOCAL_STORAGE_USER_KEY),
   isLoggedIn: false,
   isInitiated: false,
 };

--- a/src/pages/UserPage/ui/SessionControlSection/SessionControlSection.tsx
+++ b/src/pages/UserPage/ui/SessionControlSection/SessionControlSection.tsx
@@ -7,23 +7,20 @@ import { classNames } from 'shared/lib/classNames/classNames';
 import { Button } from 'shared/ui/Button/Button';
 import { formatDate } from 'shared/lib/formatDate/formatDate';
 import {
-  getUserLastSessionId,
   getUserSessions,
-  fetchLestaUserSessionById,
-  fetchUserDataByLestaId,
+  fetchLestaUserSessionById, fetchUserDataByLestaId, getUserLestaId, getUserLastSessionId,
 } from 'entities/Lesta';
 import { useAppDispatch } from 'shared/hooks/useAppDispatch/useAppDispatch';
-import { getLestaAccessToken } from 'entities/User';
+import { getLestaAccessToken } from 'entities/User/index';
 import cls from './SessionControlSection.module.scss';
 
 interface SessionControlSectionProps {
   className?: string;
-  id?: number;
 }
 
 export const SessionControlSection = memo((props: SessionControlSectionProps) => {
   const {
-    className, id,
+    className,
   } = props;
   const { t } = useTranslation();
 
@@ -32,20 +29,31 @@ export const SessionControlSection = memo((props: SessionControlSectionProps) =>
 
   const dispatch = useAppDispatch();
   const userSessions = useSelector(getUserSessions);
-  const reversedUserSessions = useMemo(() => (userSessions ? [...userSessions].reverse() : []), [userSessions]);
-  const userLastSession = useSelector(getUserLastSessionId);
+  const userId = useSelector(getUserLestaId);
   const lestaAccessToken = useSelector(getLestaAccessToken);
+  const lastSessionId = useSelector(getUserLastSessionId);
+  const reversedUserSessions = useMemo(() => (userSessions ? [...userSessions].reverse() : []), [userSessions]);
+
+  useEffect(() => {
+    setCurrentSession(lastSessionId);
+  }, [lastSessionId]);
 
   const handleUpdateSessionData = useCallback(() => {
-    dispatch(fetchLestaUserSessionById(
-      { sessionId: currentSession },
-    ));
-
     dispatch(fetchUserDataByLestaId({
-      id: Number(id),
+      id: userId,
       lestaAccessToken,
-    }));
-  }, [id, dispatch, currentSession, lestaAccessToken]);
+    }))
+      .unwrap()
+      .then((res) => {
+        const sessionId = res.userData.personal.sessions.length > 0
+          ? [...res.userData.personal.sessions].pop().id
+          : null;
+
+        if (sessionId) {
+          dispatch(fetchLestaUserSessionById({ sessionId: currentSession }));
+        }
+      });
+  }, [dispatch, userId, lestaAccessToken, currentSession]);
 
   const handleChangeSession = useCallback((targetSession) => {
     dispatch(fetchLestaUserSessionById({ sessionId: targetSession }));
@@ -57,12 +65,6 @@ export const SessionControlSection = memo((props: SessionControlSectionProps) =>
     e.stopPropagation();
     setIsMenuOpen(!isMenuOpen);
   }, [isMenuOpen]);
-
-  useEffect(() => {
-    if (userLastSession && currentSession === null) {
-      setCurrentSession(userLastSession.id);
-    }
-  }, [currentSession, userLastSession]);
 
   if (!userSessions || !reversedUserSessions) return <div className={cls.sessionListContainer} />;
 

--- a/src/widgets/UserProfile/ui/UserPrivateDataList/UserPrivateDataList.module.scss
+++ b/src/widgets/UserProfile/ui/UserPrivateDataList/UserPrivateDataList.module.scss
@@ -18,6 +18,6 @@
   }
 
   .skeleton {
-    margin-bottom: 20px;
+    min-height: 58px;
   }
 }

--- a/src/widgets/UserProfile/ui/UserProfile/UserProfile.module.scss
+++ b/src/widgets/UserProfile/ui/UserProfile/UserProfile.module.scss
@@ -4,7 +4,7 @@
   border-radius: 0 0 15px 15px;
   display: grid;
   justify-content: center;
-  grid-template: "privateData privateData privateData" 50px "avatar publicData rating" 1fr "avatar publicData social" auto / auto 1fr auto;
+  grid-template: "privateData privateData privateData" 50px "avatar publicData rating" 1fr "avatar publicData social" 31px / auto 1fr auto;
 }
 
 .avatarWrapper {

--- a/src/widgets/UserProfile/ui/UserSocialLinks/UserSocialLinks.module.scss
+++ b/src/widgets/UserProfile/ui/UserSocialLinks/UserSocialLinks.module.scss
@@ -1,6 +1,6 @@
 .socials {
   grid-area: social;
-  padding-top: 20px;
+  padding-top: 15px;
   margin: 0 auto;
   list-style: none;
   display: flex;

--- a/src/widgets/UserProfile/ui/UserSocialLinks/UserSocialLinks.tsx
+++ b/src/widgets/UserProfile/ui/UserSocialLinks/UserSocialLinks.tsx
@@ -81,7 +81,7 @@ export const UserSocialLinks = memo((props: UserSocialLinksProps) => {
         {[...new Array(2)].map((_, index) => (
           // eslint-disable-next-line react/no-array-index-key
           <li key={index} className={cls.socialElement}>
-            <Skeleton width={40} height={40} borderRadius="50%" />
+            <Skeleton width={31} height={31} borderRadius="50%" />
           </li>
         ))}
       </ul>

--- a/src/widgets/UserStats/ui/UserStats/UserStats.tsx
+++ b/src/widgets/UserStats/ui/UserStats/UserStats.tsx
@@ -6,7 +6,7 @@ import { Button } from 'shared/ui/Button/Button';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import {
-  createLestaUserSession,
+  createLestaUserSession, fetchLestaUserSessionById,
   getUserRatingStats,
   getUserSessionDelta,
   getUserSessionStats,
@@ -45,7 +45,12 @@ export const UserStats = memo(({
   const sessionStatItems = useMemo(() => getStatsList(userSessionStats), [userSessionStats]);
 
   const handleUpdateSession = useCallback(() => {
-    dispatch(createLestaUserSession());
+    dispatch(createLestaUserSession())
+      .unwrap()
+      .then((res) => {
+        const sessionId = [...res].pop().id;
+        dispatch(fetchLestaUserSessionById({ sessionId }));
+      });
   }, [dispatch]);
 
   return (


### PR DESCRIPTION
Пофикшены двойные и некорректные запросы по сессии, что приводило к рендеру левых данных до тех пор, пока не зарезолвится запрос по актуальной сессии.
В 2 раза уменьшено количество лишних ререндеров.
И поправлены скелетоны. Теперь верстка не дергается после загрузок.