### PR TITLE
lazyRetry

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,8 @@
   <!--  <meta name="theme-color" media="(prefers-color-scheme: light)" content="#d7d7e1" />-->
   <meta name="theme-color" media="(prefers-color-scheme: light)" content="#0C0C0E">
   <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0C0C0E">
+  <meta property="description" content="Современный сервис статистики и отслеживания игровых сессий для игры Tanks Blitz с учетом показателя WN8. Получайте подробную информацию о своих игровых сессиях, сравнивайте статистику с другими игроками и улучшайте свою эффективность в игре." />
+  <meta name="keywords" content="статистика вот блиц, статистика блиц, статистика tanks blitz, блиц статистика, статистика танкс блиц, wot blitz статистика, wn8, wn8 tanks blitz, вот блиц статистика игрока, игровая статистика, статистика игровых сессий, сессионка tanks blitz, неофициальная статистика tanks blitz, сессия танк блиц, tanks blitz статистика игрока, статистика tanks blitz по нику, blitzstats, blitzstats lesta">
   <meta property="og:url" content="https://blitzstats.ru" />
   <meta property="og:title" content="Статистика и турниры Tanks Blitz | BlitzStats.ru" />
   <meta property="og:description" content="Неофициальный сервис статистики и отслеживания игровых сессий для игры Tanks Blitz" />

--- a/src/pages/AuthorizationPage/ui/AuthorizationPage.lazy.tsx
+++ b/src/pages/AuthorizationPage/ui/AuthorizationPage.lazy.tsx
@@ -1,3 +1,9 @@
 import { lazy } from 'react';
+import lazyRetry from 'shared/lib/lazyRetry/lazyRetry';
 
-export const AuthorizationPageLazy = lazy(() => import('./AuthorizationPage'));
+export const AuthorizationPageLazy = lazy(
+  () => lazyRetry(
+    () => import('./AuthorizationPage'),
+    'AuthorizationPage',
+  ),
+);

--- a/src/pages/MainPage/ui/MainPage.lazy.tsx
+++ b/src/pages/MainPage/ui/MainPage.lazy.tsx
@@ -1,3 +1,9 @@
 import { lazy } from 'react';
+import lazyRetry from 'shared/lib/lazyRetry/lazyRetry';
 
-export const MainPageLazy = lazy(() => import('./MainPage'));
+export const MainPageLazy = lazy(
+  () => lazyRetry(
+    () => import('./MainPage'),
+    'MainPage',
+  ),
+);

--- a/src/pages/OpenAuthPage/ui/OpenAuthPage.lazy.tsx
+++ b/src/pages/OpenAuthPage/ui/OpenAuthPage.lazy.tsx
@@ -1,3 +1,9 @@
 import { lazy } from 'react';
+import lazyRetry from 'shared/lib/lazyRetry/lazyRetry';
 
-export const OpenAuthPageLazy = lazy(() => import('./OpenAuthPage'));
+export const OpenAuthPageLazy = lazy(
+  () => lazyRetry(
+    () => import('./OpenAuthPage'),
+    'OpenAuthPage',
+  ),
+);

--- a/src/pages/RatingPage/ui/RatingPage.lazy.ts
+++ b/src/pages/RatingPage/ui/RatingPage.lazy.ts
@@ -1,3 +1,9 @@
 import { lazy } from 'react';
+import lazyRetry from 'shared/lib/lazyRetry/lazyRetry';
 
-export const RatingPageLazy = lazy(() => import('./RatingPage'));
+export const RatingPageLazy = lazy(
+  () => lazyRetry(
+    () => import('./RatingPage'),
+    'RatingPage',
+  ),
+);

--- a/src/pages/UserPage/ui/UserPage.lazy.tsx
+++ b/src/pages/UserPage/ui/UserPage.lazy.tsx
@@ -1,3 +1,9 @@
 import { lazy } from 'react';
+import lazyRetry from 'shared/lib/lazyRetry/lazyRetry';
 
-export const UserPageLazy = lazy(() => import('./UserPage'));
+export const UserPageLazy = lazy(
+  () => lazyRetry(
+    () => import('./UserPage'),
+    'UserPage',
+  ),
+);

--- a/src/pages/UserProfilePage/ui/UserProfilePage.lazy.tsx
+++ b/src/pages/UserProfilePage/ui/UserProfilePage.lazy.tsx
@@ -1,3 +1,9 @@
 import { lazy } from 'react';
+import lazyRetry from 'shared/lib/lazyRetry/lazyRetry';
 
-export const UserProfilePageLazy = lazy(() => import('./UserProfilePage'));
+export const UserProfilePageLazy = lazy(
+  () => lazyRetry(
+    () => import('./UserProfilePage'),
+    'UserProfilePage',
+  ),
+);

--- a/src/shared/lib/lazyRetry/lazyRetry.ts
+++ b/src/shared/lib/lazyRetry/lazyRetry.ts
@@ -1,0 +1,36 @@
+import { ComponentType, lazy } from 'react';
+
+function lazyRetry<T extends ComponentType<any>>(
+  componentImport: Parameters<typeof lazy<T>>[0],
+  chunkIdentifier: string,
+): Promise<{ default: T }> {
+  const sessionStorageKey = `retry-lazy-refreshed-${chunkIdentifier}`;
+
+  return new Promise((resolve, reject) => {
+    // check if the window has already been refreshed due to this chunk
+    const hasRefreshed = JSON.parse(
+      window.sessionStorage.getItem(sessionStorageKey) || 'false',
+    );
+
+    // try to import the component
+    componentImport()
+      .then((component) => {
+        // success so reset the refresh state
+        window.sessionStorage.setItem(sessionStorageKey, 'false');
+        resolve(component);
+      })
+      .catch((error) => {
+        if (!hasRefreshed) {
+          // not been refreshed yet
+          window.sessionStorage.setItem(sessionStorageKey, 'true');
+          // refresh the page
+          return window.location.reload();
+        }
+
+        // Default error behaviour as already tried refresh
+        return reject(error);
+      });
+  });
+}
+
+export default lazyRetry;


### PR DESCRIPTION
PR добавляет lazyRetry, который будет отлавливать ошибки загрузки чанков и обновлять страницу.
Пользователь не должен увидеть никаких ошибок в проде. В случае если у него как-то не обновился билд и имеется старая ссылка на чанк, то lazyRetry это отловит и обновит страницу, загрузив свежие данные.